### PR TITLE
#3 Fix broken Card layout

### DIFF
--- a/src/components/Sections/EventList.astro
+++ b/src/components/Sections/EventList.astro
@@ -59,9 +59,9 @@ const events = allEvents
           
           <p class="text-gray-700 mb-4">{event.data.summary}</p>
           
-          <a href={`/events/${event.slug}`} class="text-primary-600 font-medium hover:text-primary-700">
+          <p class="text-primary-600 font-medium group-hover:underline group-hover:text-primary-700">
             Learn More →
-          </a>
+          </p>
         </Card>
       ))}
     </div>

--- a/src/components/Sections/SermonList.astro
+++ b/src/components/Sections/SermonList.astro
@@ -66,10 +66,11 @@ const sermons = allSermons
           )}
           
           <p class="text-gray-700 mb-4">{sermon.data.summary}</p>
-          
-          <a href={`/sermons/${sermon.slug}`} class="text-primary-600 font-medium hover:text-primary-700">
+
+          <p class="text-primary-600 font-medium group-hover:underline group-hover:text-primary-700">
             Listen Now →
-          </a>
+          </p>
+          
         </Card>
       ))}
     </div>

--- a/src/components/UI/Card.astro
+++ b/src/components/UI/Card.astro
@@ -7,29 +7,42 @@ export interface Props {
   };
   href?: string;
   className?: string;
+  imageLayout?: 'top' | 'background';
 }
 
-const { title, image, href, className = "" } = Astro.props;
+const { title, image, href, className = "", imageLayout = 'top' } = Astro.props;
 const Element = href ? "a" : "div";
 ---
 
 <Element
   href={href}
-  class={`card relative overflow-hidden group ${className}`}
+  aria-label={href ? title : undefined}
+  class:list={[
+    'card group overflow-hidden',
+    { 'relative': imageLayout === 'background' },
+    className
+  ]}
 >
   {image && (
-    <!-- full-cover image -->
-    <div class="absolute inset-0 overflow-hidden">
+    <div class:list={[
+      'overflow-hidden',
+      { 'absolute inset-0': imageLayout === 'background' }
+    ]}>
       <img
         src={image.src}
         alt={image.alt}
-        class="w-full h-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
+        class:list={[
+          "w-full object-cover object-center transition-transform duration-300 group-hover:scale-105",
+          { 'h-full': imageLayout === 'background', 'h-auto': imageLayout === 'top' }
+        ]}
       />
     </div>
   )}
 
-  <!-- konten di atas gambar -->
-  <div class="relative p-5">
+  <div class:list={[
+    'p-5',
+    { 'relative': imageLayout === 'background' }
+  ]}>
     <h3 class="mb-2 text-xl font-bold">{title}</h3>
     <div class="text-gray-700">
       <slot />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -155,10 +155,10 @@ const tags = [...new Set(posts.flatMap(post => post.data.tags))];
                     </div>
                   )
                 }
-                
-                <a href={`/blog/${post.slug}`} class="text-primary-600 font-medium hover:text-primary-700">
+
+                <p class="text-primary-600 font-medium group-hover:underline group-hover:text-primary-700">
                   Read More →
-                </a>
+                </p>
               </Card>
             ))}
           </div>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -75,9 +75,9 @@ const pastEvents = allEvents.filter(event => isPastDate(event.data.date))
             
             <p class="text-gray-700 mb-4">{event.data.summary}</p>
             
-            <a href={`/events/${event.slug}`} class="text-primary-600 font-medium hover:text-primary-700">
+            <p class="text-primary-600 font-medium group-hover:underline group-hover:text-primary-700">
               Learn More →
-            </a>
+            </p>
           </Card>
         ))}
       </div>
@@ -123,10 +123,10 @@ const pastEvents = allEvents.filter(event => isPastDate(event.data.date))
                 </div>
                 
                 <p class="text-gray-700 mb-4">{event.data.summary}</p>
-                
-                <a href={`/events/${event.slug}`} class="text-primary-600 font-medium hover:text-primary-700">
+
+                <p class="text-primary-600 font-medium group-hover:underline group-hover:text-primary-700">
                   View Details →
-                </a>
+                </p>
               </Card>
             ))}
           </div>

--- a/src/pages/sermons/index.astro
+++ b/src/pages/sermons/index.astro
@@ -170,10 +170,10 @@ const speakers = [...new Set(sermons.map(sermon => sermon.data.speaker))];
                 )}
                 
                 <p class="text-gray-700 mb-4">{sermon.data.summary}</p>
-                
-                <a href={`/sermons/${sermon.slug}`} class="text-primary-600 font-medium hover:text-primary-700">
+
+                <p class="text-primary-600 font-medium group-hover:underline group-hover:text-primary-700">
                   Listen/Watch →
-                </a>
+                </p>
               </Card>
             ))}
           </div>


### PR DESCRIPTION
- Make one link wrap the image and the texts of the card instances.
- Add an option to use the card image as the background of the text (instead of the hardcoded absolute positioning of the image).
- Add `aria-label` to the card link to prevent screen readers from reading out all content of the card as link text.